### PR TITLE
Fix mail parsing with non-breaking space

### DIFF
--- a/parseUbuntu.py
+++ b/parseUbuntu.py
@@ -18,6 +18,7 @@ import re
 import traceback
 import sys
 import xml.etree.cElementTree as XML
+import io
 
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -67,7 +68,7 @@ class MessagePackageInfo:
         self.version = pkg_version
 
 class MessageParser(object):
-    RELEASE = "(?P<release>Ubuntu \d\d.\d\d LTS)"
+    RELEASE = "(?P<release>Ubuntu \d\d.\d\d (LTS|ESM))"
     REFERENCES = "References:"
     SUMMARY = "Summary:"
     UPDATEINS = "Update instructions:"
@@ -252,7 +253,8 @@ class MessageArchiveFile(MessageParser):
         self.inputFile = input_file
 
     def parse(self):
-        inputData = open(self.inputFile).read()
+        inputData = io.open(self.inputFile, 'r', encoding='utf-8').read()
+        inputData = inputData.replace(u'\xa0', u' ')
 
         self.parsedMessages = list()
         

--- a/parseUbuntu.py
+++ b/parseUbuntu.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Author: philipp.schuler@holidaycheck.com
+# Author: philipp.schuler@holidaycheck.com, deynekoaa@gmail.com
 # 
 # Changelog:
 # 
@@ -278,7 +278,6 @@ def main():
         opt = XML.Element('opt')
         for advisory in parsed_messages:
             adv = XML.SubElement(opt, advisory.getAdvisoryName())
-
             adv.set('description', advisory.errataDesc.strip())
             adv.set('issue_date', advisory.errataDate)
             adv.set('errataFrom', advisory.errataFrom)

--- a/parseUbuntu.py
+++ b/parseUbuntu.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Author: philipp.schuler@holidaycheck.com, deynekoaa@gmail.com
+# Author: philipp.schuler@holidaycheck.com
 # 
 # Changelog:
 # 
@@ -18,6 +18,7 @@ import re
 import traceback
 import sys
 import xml.etree.cElementTree as XML
+import io
 
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -67,7 +68,7 @@ class MessagePackageInfo:
         self.version = pkg_version
 
 class MessageParser(object):
-    RELEASE = "(?P<release>Ubuntu \d\d.\d\d LTS)"
+    RELEASE = "(?P<release>Ubuntu \d\d.\d\d (LTS|ESM))"
     REFERENCES = "References:"
     SUMMARY = "Summary:"
     UPDATEINS = "Update instructions:"
@@ -252,7 +253,8 @@ class MessageArchiveFile(MessageParser):
         self.inputFile = input_file
 
     def parse(self):
-        inputData = open(self.inputFile).read()
+        inputData = io.open(self.inputFile, 'r', encoding='utf-8').read()
+        inputData = inputData.replace(u'\xa0', u' ')
 
         self.parsedMessages = list()
         
@@ -276,6 +278,7 @@ def main():
         opt = XML.Element('opt')
         for advisory in parsed_messages:
             adv = XML.SubElement(opt, advisory.getAdvisoryName())
+
             adv.set('description', advisory.errataDesc.strip())
             adv.set('issue_date', advisory.errataDate)
             adv.set('errataFrom', advisory.errataFrom)


### PR DESCRIPTION
- The update, for example [2021-June.txt.gz](https://lists.ubuntu.com/archives/ubuntu-security-announce/2021-June.txt.gz) on USN-4991-1, contains non-breaking space (`\xc2\xa0`). Error leads to empty list of updated packages
- add ESM parse support